### PR TITLE
qspiremote: replace sprintf by asprintf to fix compile warning

### DIFF
--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -33,7 +33,6 @@ jobs:
           cmake $GITHUB_WORKSPACE \
            -DCMAKE_PREFIX_PATH="$HOME/install/usr;/usr" \
            -DCMAKE_INSTALL_PREFIX:PATH="$HOME/install/usr" \
-           -DCMAKE_INSTALL_SYSCONFDIR="$HOME/install/etc" \
-           -DfirstBuild=ON
+           -DCMAKE_INSTALL_SYSCONFDIR="$HOME/install/etc"
           # compile / install
            make -j $(getconf _NPROCESSORS_ONLN)

--- a/src/spidevice/qspiremote.cpp
+++ b/src/spidevice/qspiremote.cpp
@@ -461,7 +461,7 @@ void QSPIDeviceServerClient::logData(QString strLead, QByteArray data)
     strLog = strLead;
     for(int iByte=0; iByte<data.count(); iByte++) {
         quint8 ui8Val = static_cast<quint8>(data.at(iByte));
-        strByte.sprintf(" %02X", ui8Val);
+        strByte.asprintf(" %02X", ui8Val);
         strLog += strByte;
     }
     qInfo("%s", qPrintable(strLog));


### PR DESCRIPTION
Build tested on Qt 5.14.2 & Qt 5.15.2

Signed-off-by: Andreas Müller <schnitzeltony@gmail.com>