### PR TITLE
CMake: Set COMPATIBILITY correctly

### DIFF
--- a/src/actuasense/CMakeLists.txt
+++ b/src/actuasense/CMakeLists.txt
@@ -60,7 +60,7 @@ include(CMakePackageConfigHelpers)
 write_basic_package_version_file(
     actuasenseConfigVersion.cmake
     VERSION ${PACKAGE_VERSION}
-    COMPATIBILITY SameMinorVersion
+    COMPATIBILITY SameMajorVersion
     )
 
 # configure *Config.cmake

--- a/src/bitinputpoller/CMakeLists.txt
+++ b/src/bitinputpoller/CMakeLists.txt
@@ -60,7 +60,7 @@ include(CMakePackageConfigHelpers)
 write_basic_package_version_file(
     bitinputpollerConfigVersion.cmake
     VERSION ${PACKAGE_VERSION}
-    COMPATIBILITY SameMinorVersion
+    COMPATIBILITY SameMajorVersion
     )
 
 # configure *Config.cmake

--- a/src/relaymapper/CMakeLists.txt
+++ b/src/relaymapper/CMakeLists.txt
@@ -62,7 +62,7 @@ include(CMakePackageConfigHelpers)
 write_basic_package_version_file(
     relaymapperConfigVersion.cmake
     VERSION ${PACKAGE_VERSION}
-    COMPATIBILITY SameMinorVersion
+    COMPATIBILITY SameMajorVersion
     )
 
 # configure *Config.cmake

--- a/src/remotecommon/CMakeLists.txt
+++ b/src/remotecommon/CMakeLists.txt
@@ -60,7 +60,7 @@ include(CMakePackageConfigHelpers)
 write_basic_package_version_file(
     remotecommonConfigVersion.cmake
     VERSION ${PACKAGE_VERSION}
-    COMPATIBILITY SameMinorVersion
+    COMPATIBILITY SameMajorVersion
     )
 
 # configure *Config.cmake

--- a/src/serialportasyncblock/CMakeLists.txt
+++ b/src/serialportasyncblock/CMakeLists.txt
@@ -61,7 +61,7 @@ include(CMakePackageConfigHelpers)
 write_basic_package_version_file(
     serialportasyncblockConfigVersion.cmake
     VERSION ${PACKAGE_VERSION}
-    COMPATIBILITY SameMinorVersion
+    COMPATIBILITY SameMajorVersion
     )
 
 # configure *Config.cmake

--- a/src/spidevice/CMakeLists.txt
+++ b/src/spidevice/CMakeLists.txt
@@ -62,7 +62,7 @@ include(CMakePackageConfigHelpers)
 write_basic_package_version_file(
     spideviceConfigVersion.cmake
     VERSION ${PACKAGE_VERSION}
-    COMPATIBILITY SameMinorVersion
+    COMPATIBILITY SameMajorVersion
     )
 
 # configure *Config.cmake


### PR DESCRIPTION
Not only that SameMinorVersion makes no sense - elser versions of cmake don't
support it.

Signed-off-by: Andreas Müller <schnitzeltony@gmail.com>